### PR TITLE
Add join/leave delegates to Events

### DIFF
--- a/Docs/Events/JoinLeaveRoom.md
+++ b/Docs/Events/JoinLeaveRoom.md
@@ -1,4 +1,28 @@
 ### JoinLeaveRoom
+You can get room join/leave events with two different methods:
+ - [delegates](#delegates)
+ - [events](#events)
+
+#### Delegates
+You can subscribe join/leave methods to the following:
+```cs
+void OnJoinedRoom(string roomcode, string gamemode);
+void OnLeaveRoom();
+void OnOtherLeaveRoom(Player leavingPlayer);
+```
+Example:
+```cs
+void OnJoinedRoom(string _roomCode, string _gamemode) =>
+    Debug.Log($"room code: {_roomCode}, gamemode: {_gamemode}");
+
+void OnLeaveRoom() =>
+    Debug.Log("im outta here bye");
+
+Events.OnJoinedRoom += OnJoinedRoom
+Events.OnLeaveRoom += OnLeaveRoom
+```
+
+#### Events
 These events will run when you leave or join a room.
 Example:
 ```cs

--- a/Events/Events.cs
+++ b/Events/Events.cs
@@ -22,6 +22,10 @@ namespace HoneyLib.Events
         public static EventHandler LeftRoom;
         public static EventHandler<OtherLeaveJoinArgs> OtherLeftRoom;
 
+        public static event Action OnEnterRoom = delegate { };
+        public static event Action OnLeaveRoom = delegate { };
+        public static event Action OnOtherLeaveRoom = delegate { };
+
         // public virtual void TriggerInfectionTagMaster(InfectionTagMasterArgs args) => InfectionTagMaster?.SafeInvoke(this, args);
         // public virtual void TriggerPreInfectionTagMaster(InfectionTagMasterArgs args) => PreInfectionTagMaster?.SafeInvoke(this, args);
         // public virtual void TriggerInfectionTagEvent(InfectionTagEventArgs args) => InfectionTagEvent?.SafeInvoke(this, args);

--- a/Events/Events.cs
+++ b/Events/Events.cs
@@ -22,9 +22,9 @@ namespace HoneyLib.Events
         public static EventHandler LeftRoom;
         public static EventHandler<OtherLeaveJoinArgs> OtherLeftRoom;
 
-        public static event Action OnEnterRoom = delegate { };
+        public static event Action<string, string> OnEnterRoom = delegate { };
         public static event Action OnLeaveRoom = delegate { };
-        public static event Action OnOtherLeaveRoom = delegate { };
+        public static event Action<Player> OnOtherLeaveRoom = delegate { };
 
         // public virtual void TriggerInfectionTagMaster(InfectionTagMasterArgs args) => InfectionTagMaster?.SafeInvoke(this, args);
         // public virtual void TriggerPreInfectionTagMaster(InfectionTagMasterArgs args) => PreInfectionTagMaster?.SafeInvoke(this, args);

--- a/Events/HoneyLibCallbacks.cs
+++ b/Events/HoneyLibCallbacks.cs
@@ -8,18 +8,20 @@ namespace HoneyLib.Events
         Events events = new Events();
         public override void OnJoinedRoom()
         {
+            string gamemode = "unassigned";
+                
+            if (PhotonNetwork.CurrentRoom.CustomProperties.TryGetValue("gameMode", out var gamemodeObject))
+                gamemode = gamemodeObject as string;
+
             if (Events.JoinedRoom != null)
             {
-                string gamemode = "unassigned";
-                if (PhotonNetwork.CurrentRoom.CustomProperties.TryGetValue("gameMode", out var gamemodeObject))
-                {
-                    gamemode = gamemodeObject as string;
-                }
                 RoomArgs args = new RoomArgs();
                 args.gamemode = gamemode;
                 events.TriggerJoinedRoom(args);
                 Utils.RoomUtils.RoomUtils.InRoom = true;
             }
+
+            Events.OnJoinedRoom(PhotonNetwork.CurrentRoom.Name, gamemode);
         }
 
         public override void OnLeftRoom()
@@ -29,6 +31,8 @@ namespace HoneyLib.Events
                 events.TriggerLeftRoom();
                 Utils.RoomUtils.RoomUtils.InRoom = false;
             }
+
+            Events.OnLeaveRoom();
         }
 
         public override void OnPlayerLeftRoom(Player otherPlayer)
@@ -41,6 +45,8 @@ namespace HoneyLib.Events
 
                 events.TriggerOtherLeftRoom(args);
             }
+
+            Events.OnOtherLeaveRoom(otherPlayer);
         }
     }
 }


### PR DESCRIPTION
Makes subscribing to join/leave events a little easier to do by adding delegates alongside them
The old events were left in place because there really isn't a reason to remove them besides saving about 10 lines of code